### PR TITLE
Refactored code to protocol oriented

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,10 +6,15 @@ DEPENDENCIES:
   - CryptoSwift
   - Geth (= 1.8.2)
 
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - CryptoSwift
+    - Geth
+
 SPEC CHECKSUMS:
   CryptoSwift: 4b07d5b508c1eb67bfa314a727b705f8048a85de
   Geth: 683cf31f60d46479803484611505e2424230e0a0
 
 PODFILE CHECKSUM: 32eff33f7588558eaf0e30c1c70bbdf2b3f1e224
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.0

--- a/Source/Abi/DataTypes/EthFunction.swift
+++ b/Source/Abi/DataTypes/EthFunction.swift
@@ -10,10 +10,10 @@ import Foundation
 
 open class EthFunction {
     private var _name: String!
-    private var _inputParameters: Array<Any>!
-    private var _outputParameters: Array<Any>?
+    private var _inputParameters: Array<EthEncodable>!
+    private var _outputParameters: Array<EthEncodable>?
     
-    public init(name: String, inputParameters: Array<Any>, outputParameters: Array<Any>? = nil) {
+    public init(name: String, inputParameters: Array<EthEncodable>, outputParameters: Array<EthEncodable>? = nil) {
         _name = name
         _inputParameters = inputParameters
         _outputParameters = outputParameters
@@ -23,11 +23,11 @@ open class EthFunction {
         return _name
     }
     
-    public func getInputParameters() -> Array<Any> {
+    public func getInputParameters() -> Array<EthEncodable> {
         return _inputParameters
     }
     
-    public func getOutputParameters() -> Array<Any>? {
+    public func getOutputParameters() -> Array<EthEncodable>? {
         return _outputParameters
     }
     

--- a/Source/Abi/DataTypes/EthType.swift
+++ b/Source/Abi/DataTypes/EthType.swift
@@ -13,19 +13,5 @@ public struct EthType {
     public static var MAX_BYTE_LENGTH: Int {
         return MAX_BIT_LENGTH / 8
     }
-    
-    public static func getTypeAsString(_ param: Any) -> String {
-        let typeOfParam = "\(type(of: param))"
-        
-        switch typeOfParam {
-        case "GethAddress":
-            return "address"
-        case "GethBigInt":
-            return "uint256"
-        default:
-            return typeOfParam.lowercased()
-        }
-    }
-    
 }
 

--- a/Source/Abi/EthFunctionEncoder.swift
+++ b/Source/Abi/EthFunctionEncoder.swift
@@ -10,27 +10,26 @@ import Foundation
 import CryptoSwift
 import Geth
 
-open class EthFunctionEncoder {
+extension EthFunction {
     
-    open static let `default`: EthFunctionEncoder = {
-        return EthFunctionEncoder()
-    }()
-    
-    open func encode(_ function: EthFunction) -> Data {
-        let parameters = function.getInputParameters()
+    open func ethEncode() -> Data {
+        let parameters = self.getInputParameters()
 
-        let methodSignature = buildMethodSignature(function.getName(), parameters: parameters)
-        let methodId = buildMethodId(methodSignature)
+        let methodSignature = _buildMethodSignature(self.getName(), parameters: parameters)
+        var methodId = _buildMethodId(methodSignature)
         
         print("EthFunctionEncoder : \(methodId.toHexString())")
-        return encodeParameters(parameters, methodData: methodId)
+        
+        methodId.append(parameters.ethEncode())
+        
+        return methodId
     }
     
     
     open func encodeToValueTxFee(recipient: GethAddress, amount: GethBigInt, txFee: GethBigInt) -> Data {
-        let addressEncoded = try! EthTypeEncoder.default.encode(recipient)
-        let amountEncoded = try! EthTypeEncoder.default.encode(amount)
-        let txFeeEncoded = try! EthTypeEncoder.default.encode(txFee)
+        let addressEncoded = recipient.ethEncode()
+        let amountEncoded = amount.ethEncode()
+        let txFeeEncoded = txFee.ethEncode()
         
         var startIndex = 0
         for (index, byte) in addressEncoded.enumerated() {
@@ -48,51 +47,20 @@ open class EthFunctionEncoder {
         return combinedData
     }
     
-    open func encodeParameters(_ parameters: Array<Any>, methodData: Data) -> Data {
-        var result = methodData
-        let dynamicDataOffset: Int = _getLength(parameters) * EthType.MAX_BYTE_LENGTH
-        
-        for parameter in parameters {
-            let encodedValue = try! EthTypeEncoder.default.encode(parameter)
-            
-            if EthTypeEncoder.isDynamic(parameter) {
-                let encodedDataOffset = EthTypeEncoder.default.encode(dynamicDataOffset)
-                print("Encoded Offset \(encodedDataOffset.bytes)")
-                print("Encoded Offset hex \(encodedDataOffset.bytes.toHexString())")
-                result.append(encodedDataOffset)
-                let encodedParameter = try! EthTypeEncoder.default.encode(parameter)
-                result.append(encodedParameter)
-            } else {
-                result.append(encodedValue)
-            }
-        }
-        return result
-    }
+    
   
-    private func buildMethodSignature(_ methodName: String, parameters: Array<Any>) -> String {
+    private func _buildMethodSignature(_ methodName: String, parameters: Array<EthEncodable>) -> String {
         var methodSignature = "\(methodName)("
         
         let params = parameters.map { (parameter) -> String in
-            return EthType.getTypeAsString(parameter)
+            return parameter.typeString()
         }
         methodSignature += params.joined(separator: ",")
         methodSignature += ")"
         return methodSignature
     }
-    
-    private func _getLength(_ parameters: Array<Any>) -> Int {
-        var count = 0
-        for parameter in parameters {
-            if parameter is Array<Any> {
-                count += (parameter as! Array<Any>).count // TODO: - We need to look at this
-            } else {
-                count += 1
-            }
-        }
-        return count
-    }
 
-    private func buildMethodId(_ methodSignature: String) -> Data {
+    private func _buildMethodId(_ methodSignature: String) -> Data {
         let functionSignatureData = methodSignature.data(using: .utf8)
         let signedFunctionSignature = functionSignatureData!.sha3(SHA3.Variant.keccak256)
         let range = Range(0..<4)

--- a/Source/Crypto/SignatureData.swift
+++ b/Source/Crypto/SignatureData.swift
@@ -9,18 +9,18 @@
 import Foundation
 import CryptoSwift
 
-open class SignatureData {
+public struct SignatureData {
     private var _v: Int
     private var _r: Data
     private var _s: Data
     
-    open var v: String {
+    public var v: String {
         return String(_v)
     }
-    open var r: String {
+    public var r: String {
         return _r.toHexString()
     }
-    open var s: String {
+    public var s: String {
         return _s.toHexString()
     }
     

--- a/Source/web3swift.swift
+++ b/Source/web3swift.swift
@@ -10,7 +10,7 @@ import Foundation
 import Geth
 
 public func encode(_ function: EthFunction) -> Data {
-    return EthFunctionEncoder.default.encode(function)
+    return function.ethEncode()
 }
 
 public func sign(address: GethAddress, encodedFunctionData: Data, nonce: Int64, gasLimit: GethBigInt, gasPrice: GethBigInt) -> GethTransaction? {

--- a/Tests/String+ExtensionTests.swift
+++ b/Tests/String+ExtensionTests.swift
@@ -1,0 +1,31 @@
+//
+//  String+ExtensionTests.swift
+//  web3swift
+//
+//  Created by Adrian Coroian on 5/30/18.
+//  Copyright © 2018 Radical App LLC. All rights reserved.
+//
+
+import XCTest
+@testable import web3swift
+
+class StringTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testIsHexAddress() {
+        let hexAddress = "0xba221f461dcf389c92bbd5c917769e4201fb8395"
+        let nonHex = "test"
+        XCTAssertEqual(hexAddress.isHexAddress(), true, "isHexAddress should return true for a real hex address")
+        XCTAssertEqual(nonHex.isHexAddress(), false, "isHexAddress should return false for a nonhex value")
+        // Put the code you want to measure the time of here.
+    }
+}

--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3AE8C83A20BFBF44006F120E /* String+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE8C83820BFBDB7006F120E /* String+ExtensionTests.swift */; };
 		421F0BC12011798700BE59AA /* web3swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 421F0BB72011798600BE59AA /* web3swift.framework */; };
 		421F0BC62011798700BE59AA /* web3swiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 421F0BC52011798700BE59AA /* web3swiftTests.swift */; };
 		421F0BC82011798700BE59AA /* web3swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 421F0BBA2011798600BE59AA /* web3swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -42,6 +43,7 @@
 /* Begin PBXFileReference section */
 		0659C86579CDEF23AE69D10B /* Pods-web3swift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3swift.release.xcconfig"; path = "Pods/Target Support Files/Pods-web3swift/Pods-web3swift.release.xcconfig"; sourceTree = "<group>"; };
 		35AD9756ED22F4713E40EA28 /* Pods-web3swiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3swiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-web3swiftTests/Pods-web3swiftTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3AE8C83820BFBDB7006F120E /* String+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ExtensionTests.swift"; sourceTree = "<group>"; };
 		421F0BB72011798600BE59AA /* web3swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = web3swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		421F0BBA2011798600BE59AA /* web3swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = web3swift.h; sourceTree = "<group>"; };
 		421F0BBB2011798700BE59AA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 			children = (
 				421F0BC52011798700BE59AA /* web3swiftTests.swift */,
 				421F0BC72011798700BE59AA /* Info.plist */,
+				3AE8C83820BFBDB7006F120E /* String+ExtensionTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -254,7 +257,6 @@
 				421F0BB32011798600BE59AA /* Frameworks */,
 				421F0BB42011798600BE59AA /* Headers */,
 				421F0BB52011798600BE59AA /* Resources */,
-				A5AE38AF7C50FDA686772158 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -274,7 +276,6 @@
 				421F0BBD2011798700BE59AA /* Frameworks */,
 				421F0BBE2011798700BE59AA /* Resources */,
 				5360CB585F64660DE066ADC6 /* [CP] Embed Pods Frameworks */,
-				B636BE71ED8C1539B1BBA0CB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -365,36 +366,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-web3swiftTests/Pods-web3swiftTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A5AE38AF7C50FDA686772158 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-web3swift/Pods-web3swift-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B636BE71ED8C1539B1BBA0CB /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-web3swiftTests/Pods-web3swiftTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		D3996A21066DC2D04531203D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -456,6 +427,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AE8C83A20BFBF44006F120E /* String+ExtensionTests.swift in Sources */,
 				421F0BC62011798700BE59AA /* web3swiftTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/web3swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/web3swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/web3swift.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/web3swift.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Hello,

I have refactored the code to protocol oriented. 
This cleaned up some single responsibility issues.

EthTypeEncoder - can be broken up to separate files for each extension
Everything conforms to EthEncodable. The benefits are:
- no more need to throw error if type is not encodable. 
- issues are seen at compile time
- cleaner usage of encoder functions
- people can extend their type to make it encodable and usable by library.

Code has not been tested but should work the same (unless i missed someting).
TODO: Write tests to confirm everything is working